### PR TITLE
Thread test cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,9 @@ hs_err_pid*
 
 # IntelliJ
 .idea/
+/target/
+
+# Eclipse files
+.classpath
+.project
+.settings

--- a/pom.xml
+++ b/pom.xml
@@ -21,6 +21,24 @@
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <version>4.12</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.hamcrest</groupId>
+          <artifactId>hamcrest-core</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest-all</artifactId>
+      <version>1.3</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.github.fge</groupId>
+      <artifactId>throwing-lambdas</artifactId>
+      <version>0.5.0</version>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 </project>

--- a/src/test/java/ThreadTest.java
+++ b/src/test/java/ThreadTest.java
@@ -4,179 +4,150 @@ import java.util.List;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
+
+import static com.github.fge.lambdas.Throwing.consumer;
+import static com.github.fge.lambdas.Throwing.runnable;
+import static com.github.fge.lambdas.Throwing.intConsumer;
+import static java.util.stream.Collectors.toList;
+import static java.util.stream.IntStream.range;
+import static org.hamcrest.Matchers.*;
+import static org.hamcrest.MatcherAssert.*;
 
 public class ThreadTest {
 
     @Test
     public void runsOneThread() throws Exception {
+        int loops = 100;
         AtomicInteger count = new AtomicInteger(0);
 
-        Thread t1 = new Thread(()-> {
-            for(int i = 0; i < 100; i++){
-                count.incrementAndGet();
-            }
-        });
+        Thread t1 = new Thread(()->range(0, loops)
+          .forEach(i->count.incrementAndGet()));
+ 
         t1.start();
 
         t1.join();
-        System.out.println(count);
+
+        assertThat(count.get(), equalTo(loops));
     }
 
     @Test
     public void runsTwoThreads() throws Exception {
+        int loops = 100;
         AtomicInteger count = new AtomicInteger(0);
 
-        Thread t1 = new Thread(()-> {
-            for(int i = 0; i < 100; i++){
-                count.incrementAndGet();
-            }
-        });
+        Thread t1 = new Thread(()->range(0, loops)
+          .forEach(i->count.incrementAndGet()));
         t1.start();
 
-        Thread t2 = new Thread(()-> {
-            for(int i = 0; i < 100; i++){
-                count.incrementAndGet();
-            }
-        });
+        Thread t2 = new Thread(()->range(0, loops)
+          .forEach(i->count.incrementAndGet()));
         t2.start();
 
-        safeRun(t1::join).run();
-        safeRun(t2::join).run();
-        System.out.println(count);
+        t1.join();
+        t2.join();
+
+        assertThat(count.get(), equalTo(loops*2));
     }
 
     public volatile int count = 0;
 
     @Test
     public void run100ThreadsSynchronized() throws Exception {
+        int loops = 10000;
+        int threadCount = 100;
         count = 0;
-        Runnable r = safeRun(()-> {
-            for (int i = 0; i < 10000; i++) {
-                synchronized (this){count++;}
-            }
-        });
+        Runnable r = ()->range(0, loops)
+          .forEach(i->{synchronized (this){count++;}});
 
-        List<Thread> threadList = IntStream.range(0,100).mapToObj(i-> new Thread(r)).collect(Collectors.toList());
+        List<Thread> threadList = range(0,threadCount)
+          .mapToObj(i-> new Thread(r))
+          .collect(toList());
 
-        threadList.stream().forEach(t->t.start());
-        threadList.stream().forEach(t->{
-            try {
-                t.join();
-            }
-            catch (Exception e) {
-                throw new RuntimeException(e);
-            }
-        });
-        System.out.println(count);
+        threadList.stream().forEach(Thread::start);
+        threadList.stream().forEach(consumer(Thread::join));
+
+        assertThat(count, equalTo(loops*threadCount));
     }
 
     @Test
     public void run100ThreadsSemaphore() throws Exception {
+        int loops = 10000;
+        int threadCount = 100;
         State state = new State();
         Semaphore s = new Semaphore(1);
-        Runnable r = safeRun(()-> {
-            for (int i = 0; i < 10000; i++) {
+        Runnable r = runnable(()->range(0, loops)
+          .forEach(intConsumer(i->{
                 s.acquire();
                 state.count++;
                 s.release();
-            }
-        });
+            })));
 
-        List<Thread> threadList = IntStream.range(0,100).mapToObj(i-> new Thread(r)).collect(Collectors.toList());
+        List<Thread> threadList = range(0,threadCount)
+          .mapToObj(i-> new Thread(r))
+          .collect(toList());
 
-        threadList.stream().forEach(t->t.start());
-        threadList.stream().forEach(t->{
-            try {
-                t.join();
-            }
-            catch (Exception e) {
-                throw new RuntimeException(e);
-            }
-        });
-        System.out.println("MY COUNT: " + state.count);
+        threadList.stream().forEach(Thread::start);
+        threadList.stream().forEach(consumer(Thread::join));
+
+        assertThat(state.count, equalTo(loops*threadCount));
     }
 
     @Test
     public void run100ThreadsAtomic() throws Exception {
+        int loops = 10000;
+        int threadCount = 100;
         AtomicReference<Integer> state = new AtomicReference<>(0);
-        Runnable r = safeRun(()-> {
-            for (int i = 0; i < 10000; i++) {
-                state.getAndAccumulate(1,(x,y)->x+y);
-            }
-        });
+        Runnable r = ()->range(0, loops)
+          .forEach(i->state.getAndAccumulate(1,(x,y)->x+y));
 
-        List<Thread> threadList = IntStream.range(0,100).mapToObj(i-> new Thread(r)).collect(Collectors.toList());
+        List<Thread> threadList = range(0,threadCount)
+          .mapToObj(i-> new Thread(r))
+          .collect(toList());
 
-        threadList.stream().forEach(t->t.start());
-        threadList.stream().forEach(t->{
-            try {
-                t.join();
-            }
-            catch (Exception e) {
-                throw new RuntimeException(e);
-            }
-        });
-        System.out.println("MY COUNT: " + state.get());
+        threadList.stream().forEach(Thread::start);
+        threadList.stream().forEach(consumer(Thread::join));
+
+        assertThat(state.get(), equalTo(loops*threadCount));
     }
 
     @Test
     public void run100ThreadsLocal() throws Exception {
+        int loops = 10000;
+        int threadCount = 100;
         AtomicReference<Integer> state = new AtomicReference<>(0);
-        ThreadLocal<Integer> local = new ThreadLocal() {
+        ThreadLocal<Integer> local = new ThreadLocal<Integer>() {
             public Integer initialValue(){
                 return 0;
             }
         };
-        Runnable r = safeRun(()-> {
-            for (int i = 0; i < 10000; i++) {
-                local.set(local.get() + 1);
-            }
-            state.getAndAccumulate(local.get(),(x,y)->x+y);
-        });
+        Runnable r = ()->{
+          range(0, loops)
+            .forEach(i->local.set(local.get() + 1));
+          state.getAndAccumulate(local.get(),(x,y)->x+y);
+        };
 
-        List<Thread> threadList = IntStream.range(0,100).mapToObj(i-> new Thread(r)).collect(Collectors.toList());
+        List<Thread> threadList = range(0,threadCount)
+          .mapToObj(i-> new Thread(r))
+          .collect(toList());
 
-        threadList.stream().forEach(t->t.start());
-        threadList.stream().forEach(t->{
-            try {
-                t.join();
-            }
-            catch (Exception e) {
-                throw new RuntimeException(e);
-            }
-        });
-        System.out.println("MY COUNT: " + state.get());
+        threadList.stream().forEach(Thread::start);
+        threadList.stream().forEach(consumer(Thread::join));
+
+        assertThat(state.get(), equalTo(loops*threadCount));
     }
 
     public static class State {
         volatile int count = 0;
     }
 
-    public static interface ThrowingRunnable {
-        public void run() throws Exception;
-    }
-
-    public static Runnable safeRun( ThrowingRunnable c ) {
-        return () ->{ try {
-            c.run();
-        }
-        catch (Exception e) {
-            throw new RuntimeException(e);
-        }   };
-    }
-
     @Test
     public void runsNoThread() {
+        int loops = 100;
         AtomicInteger count = new AtomicInteger(0);
 
+        range(0, loops)
+          .forEach(i->count.incrementAndGet());
 
-        for(int i = 0; i < 100; i++){
-            count.incrementAndGet();
-        }
-
-
-        System.out.println(count);
+        assertThat(count.get(), equalTo(loops));
     }
 }


### PR DESCRIPTION
This cleans up some of the oddness in this example from our meeting yesterday.

- Included a library to help clean up interface between Stream API and functions that throw exceptions.
- Consolidated looping code with streams.
- Converted hand written lambdas to method references.